### PR TITLE
Update GlobalVariables type hint

### DIFF
--- a/app/Resources/views/Areas/gallery-carousel/view.html.php
+++ b/app/Resources/views/Areas/gallery-carousel/view.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 ?>
 

--- a/app/Resources/views/Areas/gallery-single-images/view.html.php
+++ b/app/Resources/views/Areas/gallery-single-images/view.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 ?>
 

--- a/app/Resources/views/Areas/horizontal-line/view.html.php
+++ b/app/Resources/views/Areas/horizontal-line/view.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 ?>
 

--- a/app/Resources/views/Areas/icon-teaser-row/view.html.php
+++ b/app/Resources/views/Areas/icon-teaser-row/view.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 ?>
 

--- a/app/Resources/views/Areas/image/view.html.php
+++ b/app/Resources/views/Areas/image/view.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 ?>
 

--- a/app/Resources/views/Areas/print-key-visual/view.html.php
+++ b/app/Resources/views/Areas/print-key-visual/view.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 ?>
 

--- a/app/Resources/views/Areas/print-pagebreak/view.html.php
+++ b/app/Resources/views/Areas/print-pagebreak/view.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 ?>
 

--- a/app/Resources/views/Areas/print-product-row/view.html.php
+++ b/app/Resources/views/Areas/print-product-row/view.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 

--- a/app/Resources/views/Areas/print-product-table/specAttribute/column-attribute-table-header.html.php
+++ b/app/Resources/views/Areas/print-product-table/specAttribute/column-attribute-table-header.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 ?>

--- a/app/Resources/views/Areas/print-product-table/specAttribute/column-attribute-table-values.html.php
+++ b/app/Resources/views/Areas/print-product-table/specAttribute/column-attribute-table-values.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 

--- a/app/Resources/views/Areas/print-product-table/specAttribute/column-attribute-table.html.php
+++ b/app/Resources/views/Areas/print-product-table/specAttribute/column-attribute-table.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 

--- a/app/Resources/views/Areas/print-product-table/specAttribute/spec-value.html.php
+++ b/app/Resources/views/Areas/print-product-table/specAttribute/spec-value.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 ?>

--- a/app/Resources/views/Areas/print-product-table/view.html.php
+++ b/app/Resources/views/Areas/print-product-table/view.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 ?>

--- a/app/Resources/views/Areas/print-title-page/view.html.php
+++ b/app/Resources/views/Areas/print-title-page/view.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 ?>

--- a/app/Resources/views/Areas/print-toc/view.html.php
+++ b/app/Resources/views/Areas/print-toc/view.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->headScript()->appendFile("/bundles/web2printtools/vendor/js/awesomizr.js");

--- a/app/Resources/views/Areas/print-wysiwyg/view.html.php
+++ b/app/Resources/views/Areas/print-wysiwyg/view.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 ?>

--- a/app/Resources/views/Areas/productgrid/view.html.php
+++ b/app/Resources/views/Areas/productgrid/view.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 

--- a/app/Resources/views/Areas/productteaser/view.html.php
+++ b/app/Resources/views/Areas/productteaser/view.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 ?>
 <div class="row">

--- a/app/Resources/views/Areas/wysiwyg/view.html.php
+++ b/app/Resources/views/Areas/wysiwyg/view.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 ?>
 

--- a/app/Resources/views/Cart/list.html.php
+++ b/app/Resources/views/Cart/list.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->extend('layout.html.php');

--- a/app/Resources/views/Checkout/completed.html.php
+++ b/app/Resources/views/Checkout/completed.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->extend('layout.html.php');

--- a/app/Resources/views/Checkout/confirm.html.php
+++ b/app/Resources/views/Checkout/confirm.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->extend('layout.html.php');

--- a/app/Resources/views/Checkout/delivery.html.php
+++ b/app/Resources/views/Checkout/delivery.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->extend('layout.html.php');

--- a/app/Resources/views/Checkout/pending.html.php
+++ b/app/Resources/views/Checkout/pending.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->extend('layout.html.php');

--- a/app/Resources/views/Checkout/steps/header.html.php
+++ b/app/Resources/views/Checkout/steps/header.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 

--- a/app/Resources/views/Checkout/steps/sidebar.html.php
+++ b/app/Resources/views/Checkout/steps/sidebar.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 

--- a/app/Resources/views/Content/default.html.php
+++ b/app/Resources/views/Content/default.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->extend('layout.html.php');

--- a/app/Resources/views/Content/landingPage.html.php
+++ b/app/Resources/views/Content/landingPage.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->extend('layout.html.php');

--- a/app/Resources/views/Content/portal.html.php
+++ b/app/Resources/views/Content/portal.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->extend('layout.html.php');

--- a/app/Resources/views/Content/tenantSwitches.html.php
+++ b/app/Resources/views/Content/tenantSwitches.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->extend('layout.html.php');

--- a/app/Resources/views/Email/orderConfirmation.html.php
+++ b/app/Resources/views/Email/orderConfirmation.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
     $this->extend('email.html.php');

--- a/app/Resources/views/Includes/content-headline.html.php
+++ b/app/Resources/views/Includes/content-headline.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
     // automatically use the headline as title

--- a/app/Resources/views/Includes/footer.html.php
+++ b/app/Resources/views/Includes/footer.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 ?>
 

--- a/app/Resources/views/Payment/payment.html.php
+++ b/app/Resources/views/Payment/payment.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->extend('layout.html.php');

--- a/app/Resources/views/Payment/paymentFrame.html.php
+++ b/app/Resources/views/Payment/paymentFrame.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->extend('payment-iframe.html.php');

--- a/app/Resources/views/Payment/paymentStatus.html.php
+++ b/app/Resources/views/Payment/paymentStatus.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 ?>

--- a/app/Resources/views/PaymentSeamless/complete.html.php
+++ b/app/Resources/views/PaymentSeamless/complete.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->headLink()->appendStylesheet('/static/bootstrap/css/bootstrap.css');

--- a/app/Resources/views/PaymentSeamless/wirecard-seamless/payment-method-selection.html.php
+++ b/app/Resources/views/PaymentSeamless/wirecard-seamless/payment-method-selection.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 ?>
 

--- a/app/Resources/views/PaymentSeamless/wirecard-seamless/payment-method/ccard.html.php
+++ b/app/Resources/views/PaymentSeamless/wirecard-seamless/payment-method/ccard.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 ?>
 

--- a/app/Resources/views/PaymentSeamless/wirecard-seamless/payment-method/invoice.html.php
+++ b/app/Resources/views/PaymentSeamless/wirecard-seamless/payment-method/invoice.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->headScript()->appendFile('/static/js/payment/wirecard-seamless/jquery-birthday-picker.min.js');

--- a/app/Resources/views/PaymentSeamless/wirecard-seamless/payment-method/prepayment.html.php
+++ b/app/Resources/views/PaymentSeamless/wirecard-seamless/payment-method/prepayment.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 ?>
 

--- a/app/Resources/views/QuickCheckout/completed.html.php
+++ b/app/Resources/views/QuickCheckout/completed.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->extend('layout.html.php');

--- a/app/Resources/views/QuickCheckout/confirm.html.php
+++ b/app/Resources/views/QuickCheckout/confirm.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->extend('layout.html.php');

--- a/app/Resources/views/QuickCheckout/payment.html.php
+++ b/app/Resources/views/QuickCheckout/payment.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->extend('layout.html.php');

--- a/app/Resources/views/QuickCheckout/paymentFrame.html.php
+++ b/app/Resources/views/QuickCheckout/paymentFrame.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->extend('payment-iframe.html.php');

--- a/app/Resources/views/QuickCheckout/steps/header.html.php
+++ b/app/Resources/views/QuickCheckout/steps/header.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
     $steps = [

--- a/app/Resources/views/Shop/detail.html.php
+++ b/app/Resources/views/Shop/detail.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
     $this->extend('layout.html.php');

--- a/app/Resources/views/Shop/filters/multiselect-notranslation.html.php
+++ b/app/Resources/views/Shop/filters/multiselect-notranslation.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 // ...

--- a/app/Resources/views/Shop/filters/multiselect-relation.html.php
+++ b/app/Resources/views/Shop/filters/multiselect-relation.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 ?>

--- a/app/Resources/views/Shop/filters/multiselect.html.php
+++ b/app/Resources/views/Shop/filters/multiselect.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 // ...

--- a/app/Resources/views/Shop/filters/numberrange.html.php
+++ b/app/Resources/views/Shop/filters/numberrange.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 // if now values available, skip this filter

--- a/app/Resources/views/Shop/filters/object_relation.html.php
+++ b/app/Resources/views/Shop/filters/object_relation.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
     $values = $this->values;

--- a/app/Resources/views/Shop/filters/range.html.php
+++ b/app/Resources/views/Shop/filters/range.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 // if now values available, skip this filter

--- a/app/Resources/views/Shop/filters/select.html.php
+++ b/app/Resources/views/Shop/filters/select.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
     $values = $this->values;

--- a/app/Resources/views/Shop/filters/select_category.html.php
+++ b/app/Resources/views/Shop/filters/select_category.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 // init

--- a/app/Resources/views/Shop/includes/pagination-search.html.php
+++ b/app/Resources/views/Shop/includes/pagination-search.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 ?>

--- a/app/Resources/views/Shop/includes/pagination.html.php
+++ b/app/Resources/views/Shop/includes/pagination.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 ?>

--- a/app/Resources/views/Shop/list.html.php
+++ b/app/Resources/views/Shop/list.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
     if($this->showLayout) {

--- a/app/Resources/views/Shop/list/product.html.php
+++ b/app/Resources/views/Shop/list/product.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  * @var $product \AppBundle\Model\DefaultProduct
  * @var $linkProdukt \AppBundle\Model\DefaultProduct
  */

--- a/app/Resources/views/Shop/list/products.html.php
+++ b/app/Resources/views/Shop/list/products.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  * @var $product \AppBundle\Model\DefaultProduct
  */
 ?>

--- a/app/Resources/views/Shop/search.html.php
+++ b/app/Resources/views/Shop/search.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->extend('layout.html.php');

--- a/app/Resources/views/Web2print/container.html.php
+++ b/app/Resources/views/Web2print/container.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 $this->extend('print.html.php');

--- a/app/Resources/views/Web2print/default.html.php
+++ b/app/Resources/views/Web2print/default.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 if(!$this->document->getProperty("hide-layout")) {

--- a/app/Resources/views/Web2print/productCell.html.php
+++ b/app/Resources/views/Web2print/productCell.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 /**

--- a/app/Resources/views/layout.html.php
+++ b/app/Resources/views/layout.html.php
@@ -16,7 +16,7 @@
 /**
  * @var \Pimcore\Templating\PhpEngine $this
  * @var \Pimcore\Templating\PhpEngine $view
- * @var \Pimcore\Templating\GlobalVariables\GlobalVariables $app
+ * @var \Pimcore\Templating\GlobalVariables $app
  */
 
 use Pimcore\Model\Document;


### PR DESCRIPTION
The `GlobalVariables` type hint needs to be changed as the class defined a wrong namespace.

See pimcore/pimcore#1470