### PR TITLE
fix syntax error, unexpected end of file in confirm.html.php checkout step

### DIFF
--- a/app/Resources/views/Checkout/confirm.html.php
+++ b/app/Resources/views/Checkout/confirm.html.php
@@ -100,7 +100,7 @@ $cart = $this->cart;
                             }
                             ?>
                         </p>
-                        <?
+                        <?php
                     elseif ($paymentProvider = $paymentProviderBrick->getPaymentProviderDatatrans()) :
                         $currentPaymentMethod = $paymentProvider->getAuth_pmethod();
                         ?>
@@ -127,7 +127,7 @@ $cart = $this->cart;
                             }
                             ?>
                         </p>
-                        <?
+                        <?php
                     endif;
                 endforeach;
                 ?>


### PR DESCRIPTION
Two `<?php` were missing. This fixes the syntax error